### PR TITLE
fixed fireball rank 12 level

### DIFF
--- a/AbilityData/TBC.lua
+++ b/AbilityData/TBC.lua
@@ -418,7 +418,7 @@ addon.AbilityData = {
   [10149] = { Rank = 9, Level = 48, AbilityGroup = 70 },
   [10150] = { Rank = 10, Level = 54, AbilityGroup = 70 },
   [10151] = { Rank = 11, Level = 60, AbilityGroup = 70 },
-  [25306] = { Rank = 12, Level = 60, AbilityGroup = 70 },
+  [25306] = { Rank = 12, Level = 62, AbilityGroup = 70 },
   [27070] = { Rank = 13, Level = 66, AbilityGroup = 70 },
   [2120] = { Rank = 1, Level = 16, AbilityGroup = 71 },
   [2121] = { Rank = 2, Level = 24, AbilityGroup = 71 },


### PR DESCRIPTION
Got a message at level 61 that I was using a Fireball (Rank 11) instead of Rank 12, went to trainer to double check that Rank 12 Fireball is indeed at level 62. Hopefully I edited the correct file. Love the addon, thanks!