### PR TITLE
Update RankSentinel-Classic.toc

### DIFF
--- a/RankSentinel-Classic.toc
+++ b/RankSentinel-Classic.toc
@@ -1,5 +1,4 @@
-## Interface: 11506
-## Interface-Classic: 11506
+## Interface: 11507
 ## Title: RankSentinel
 ## Version: @project-version@
 ## Author: SabreValkyrn


### PR DESCRIPTION
Updated Version in ToC for Classic Era / Anniversary / SoD game Client.

No longer need Interface and Classic Interface lines, I believe.