### PR TITLE
Update RankSentinel.toc

### DIFF
--- a/RankSentinel.toc
+++ b/RankSentinel.toc
@@ -1,5 +1,5 @@
-## Interface: 20505, 11508
-## Interface-Classic: 11508
+## Interface: 20506, 11509
+## Interface-Classic: 11509
 ## Title: RankSentinel
 ## Version: @project-version@
 ## Author: SabreValkyrn


### PR DESCRIPTION
Updated for new client versions.

I think... Mage Mana Gems are the only thing I'd probably say should be updated spell wise... I think it's OK to use lower ranks because you can "stack" them as backups. But meh, it's holding up well! 

Hope you are too. Cheers!